### PR TITLE
💁‍♀️ Add support for a single discard

### DIFF
--- a/OutParser.Generator/SyntaxReading.cs
+++ b/OutParser.Generator/SyntaxReading.cs
@@ -112,13 +112,21 @@ internal static class SyntaxReading {
     }
 
     private static string? GetOutParameterName(IArgumentOperation operation) {
-        if (operation.Syntax is not ArgumentSyntax syntax) {
+        if (operation.Syntax is not ArgumentSyntax argument) {
             return null;
         }
-        if (syntax.Expression is not DeclarationExpressionSyntax expression) {
+        // Discard with no type
+        if (argument.Expression is IdentifierNameSyntax { Identifier.Value: "_"}) {
+            return "_";
+        }
+        if (argument.Expression is not DeclarationExpressionSyntax declaration) {
             return null;
         }
-        if (expression.Designation is not SingleVariableDesignationSyntax designation) {
+        // Discard with type
+        if (declaration.Designation is DiscardDesignationSyntax) {
+            return "_";
+        }
+        if (declaration.Designation is not SingleVariableDesignationSyntax designation) {
             return null;
         }
         return designation.Identifier.Text;

--- a/UnitTests/CollectionTests.cs
+++ b/UnitTests/CollectionTests.cs
@@ -34,4 +34,18 @@ internal class CollectionTests {
 
         Assert.AreEqual(new int[] { 1, 2, 4, 8, 16 }, list);
     }
+
+    [Test]
+    public void TryIntArray() {
+        if (OutParser.TryParse(
+            "1,2,4,8,16",
+            "{array:,}",
+            out int[]? array
+        ) == false) {
+            Assert.Fail("Failed to parse int array");
+            return;
+        }
+
+        Assert.AreEqual(new int[] { 1, 2, 4, 8, 16 }, array);
+    }
 }

--- a/UnitTests/ParameterNameTests.cs
+++ b/UnitTests/ParameterNameTests.cs
@@ -1,0 +1,18 @@
+﻿using OutParsing;
+
+namespace UnitTests;
+internal class ParameterNameTests {
+    /*[Test]
+    public void DiscardWithType() {
+        OutParser.Parse("I eat cookies and drink milk!", "I eat {_} and drink {drink}!", out string _, out string drink);
+
+        Assert.AreEqual("milk", drink);
+    }*/
+
+    [Test]
+    public void DiscardWithoutType() {
+        OutParser.Parse<string, string>("I eat cookies and drink milk!", "I eat {_} and drink {drink}!", out _, out string drink);
+
+        Assert.AreEqual("milk", drink);
+    }
+}

--- a/UnitTests/SimpleParsingTests.cs
+++ b/UnitTests/SimpleParsingTests.cs
@@ -78,4 +78,15 @@ public class SimpleParsingTests {
         Assert.AreEqual(4, value1);
         Assert.AreEqual(9, value2);
     }
+
+    [Test]
+    public void TypeParameters() {
+        OutParser.Parse<int>(
+            "I have 69 rubber ducks",
+            "I have {x} rubber ducks",
+            out var x
+        );
+
+        Assert.AreEqual(69, x);
+    }
 }

--- a/UnitTests/TryParseTests.cs
+++ b/UnitTests/TryParseTests.cs
@@ -26,4 +26,12 @@ public class TryParseTests {
         Assert.IsFalse(success);
     }
 
+    [Test]
+    public void MultipleVariables() {
+        var success = OutParser.TryParse("I eat potato and meatballs", "I eat {food0} and {food1}", out string? food0, out string? food1);
+
+        Assert.IsTrue(success);
+        Assert.AreEqual("potato", food0);
+        Assert.AreEqual("meatballs", food1);
+    }
 }


### PR DESCRIPTION
Fixes #8 sorta. It's not built to support multiple discards, since then it will be confused which one is which if they're different types. If they're all the same type it would technically be fine but that would complicate the code significantly. Right now having multiple discards will report an error with the analyzer so this limitation is well exposed to the user so I think it's okay.